### PR TITLE
Remove Python 3.3 from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
 #  - "2.6"  # unittest.TestCase doesn't have assertIn in 2.6
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"


### PR DESCRIPTION
Remove Python 3.3 from Travis CI build env because Python 3.3 has reached EOL (ref. #33)